### PR TITLE
Add time parameter to PlayNote (Chord).

### DIFF
--- a/ABCSample/Program.cs
+++ b/ABCSample/Program.cs
@@ -34,7 +34,7 @@ namespace ABCTest {
             : base(false) {
         }
 
-        protected override void PlayNote(Note note, int channel) {
+        protected override void PlayNote(Note note, int channel, TimeSpan time) {
             // Only play melody (channel 0) and first note of chords (channel 1)
             if (channel <= 1) {
                 // length is halved because Console.Beep messes up using full length on consecutive notes

--- a/MMLSample/Program.cs
+++ b/MMLSample/Program.cs
@@ -34,7 +34,7 @@ namespace MMLTest {
             : base() {
         }
 
-        protected override void PlayNote(Note note, int channel) {
+        protected override void PlayNote(Note note, int channel, TimeSpan time) {
             // length is halved because Console.Beep messes up using full length on consecutive notes
             Console.Beep((int)note.GetFrequency(), (int)(note.Length.TotalMilliseconds * 0.5));
         }

--- a/MidiPlayer/PlayerABC.cs
+++ b/MidiPlayer/PlayerABC.cs
@@ -63,7 +63,7 @@ namespace MidiPlayer {
             base.Stop();
         }
 
-        protected override void PlayNote(Note note, int channel) {
+        protected override void PlayNote(Note note, int channel, TimeSpan time) {
             if (!Muted && channel == 0) {
                 //Console.WriteLine(lastTime + ": " + note.Type + (note.Sharp ? "#" : "") + "[" + note.Octave + "] " + note.Length);
             }
@@ -75,14 +75,14 @@ namespace MidiPlayer {
             midi.PlayNote(channel, note, elapsed + note.Length);
         }
 
-        protected override void PlayChord(List<Note> notes) {
+        protected override void PlayChord(List<Note> notes, TimeSpan time) {
             bool write = false;
             if (Muted)
                 write = false;
             if (write)
                 Console.Write(lastTime + ": Chord [");
             for (int i = 0; i < notes.Count; i++) {
-                PlayNote(notes[i], i + 1);
+                PlayNote(notes[i], i + 1, time);
                 if (write) {
                     Console.Write(" " + notes[i].Type + (notes[i].Sharp ? "#" : "") + "[" + notes[i].Octave + "] ");
                 }

--- a/MidiPlayer/PlayerMML.cs
+++ b/MidiPlayer/PlayerMML.cs
@@ -165,7 +165,7 @@ namespace MidiPlayer {
             }
         }
 
-        protected override void PlayNote(Note note, int channel) {
+        protected override void PlayNote(Note note, int channel, TimeSpan time) {
             if (normalize)
                 note.Volume = Math.Min(Math.Max(note.Volume * normalizeScalar, 0), 1);
 

--- a/PitchSample/OggMMLPlayer.cs
+++ b/PitchSample/OggMMLPlayer.cs
@@ -41,7 +41,7 @@ namespace PitchSample {
             fadingSources = new List<SoundSource>();
         }
 
-        protected override void PlayNote(Note note, int channel) {
+        protected override void PlayNote(Note note, int channel, TimeSpan time) {
             // get the pitch relative to the C note in the same octave
             var pitch = GetPitch(note);
             // get the appropriate C note sound

--- a/TextPlayer/ABC/ABCPlayer.cs
+++ b/TextPlayer/ABC/ABCPlayer.cs
@@ -323,7 +323,7 @@ namespace TextPlayer.ABC {
                             chord = false;
                             var chordLen = GetChord(chordNotes);
                             nextNote += chordLen;
-                            PlayChord(chordNotes);
+                            PlayChord(chordNotes, nextNote);
                         }
                         break;
                     case '!': // replacement for chord opener
@@ -435,7 +435,7 @@ namespace TextPlayer.ABC {
             }
         }
 
-        private void PlayChord(List<ABCNote> notes) {
+        private void PlayChord(List<ABCNote> notes, TimeSpan time) {
             List<Note> chord = new List<Note>(notes.Count);
             foreach (var note in notes) {
                 var tied = TieNote(note);
@@ -443,10 +443,10 @@ namespace TextPlayer.ABC {
                     chord.Add(tied);
                 }
             }
-            PlayChord(chord);
+            PlayChord(chord, time);
         }
 
-        protected virtual void PlayChord(List<Note> notes) {
+        protected virtual void PlayChord(List<Note> notes, TimeSpan time) {
             int i = 1;
             foreach (var note in notes) {
                 ValidateAndPlayNote(note, i++);
@@ -499,7 +499,7 @@ namespace TextPlayer.ABC {
                 note.Octave = settings.MaxOctave;
             note.Volume = Math.Max(0f, Math.Min(note.Volume, 1f));
             if (!Muted)
-                PlayNote(note, channel);
+                PlayNote(note, channel, nextNote);
         }
 
         private Note GetRest(string s) {

--- a/TextPlayer/MML/MMLPlayer.cs
+++ b/TextPlayer/MML/MMLPlayer.cs
@@ -242,7 +242,7 @@ namespace TextPlayer.MML {
                 }
                 else if (cmd.Type == MMLCommandType.Rest) {
                     double measureLength;
-                    var len = GetRest(cmd, out measureLength);
+                    GetRest(cmd, out measureLength);
                     nextNote += measureLength;
                     noteFound = true;
                 }
@@ -261,7 +261,7 @@ namespace TextPlayer.MML {
                 note.Octave = settings.MaxOctave;
             note.Volume = Math.Max(0f, Math.Min(note.Volume, 1f));
             if (!Muted)
-                PlayNote(note, 0);
+                PlayNote(note, 0, nextTick);
         }
 
         private MMLLength GetRest(MMLCommand cmd, out double measureLength) {

--- a/TextPlayer/MML/MMLPlayerTrack.cs
+++ b/TextPlayer/MML/MMLPlayerTrack.cs
@@ -37,8 +37,8 @@ namespace TextPlayer.MML {
             this.parent = parent;
         }
 
-        protected override void PlayNote(Note note, int channel) {
-            parent.PlayNote(note, channel, this);
+        protected override void PlayNote(Note note, int channel, TimeSpan time) {
+            parent.PlayNote(note, channel, this, time);
         }
 
         protected override void SetTempo(MMLCommand cmd) {

--- a/TextPlayer/MML/MultiTrackMMLPlayer.cs
+++ b/TextPlayer/MML/MultiTrackMMLPlayer.cs
@@ -50,16 +50,17 @@ namespace TextPlayer.MML {
         /// </summary>
         /// <param name="note">Note to play.</param>
         /// <param name="channel">Zero-based channel to play the note on.</param>
-        protected abstract void PlayNote(Note note, int channel);
+        /// <param name="time">Current playback time.</param>
+        protected abstract void PlayNote(Note note, int channel, TimeSpan time);
 
-        internal virtual void PlayNote(Note note, int channel, MMLPlayerTrack track) {
+        internal virtual void PlayNote(Note note, int channel, MMLPlayerTrack track, TimeSpan time) {
             if (Muted)
                 return;
 
             int index = tracks.IndexOf(track);
             if (index < 0)
                 return;
-            PlayNote(note, index);
+            PlayNote(note, index, time);
         }
 
         /// <summary>

--- a/TextPlayer/MusicPlayer.cs
+++ b/TextPlayer/MusicPlayer.cs
@@ -148,7 +148,8 @@ namespace TextPlayer {
         /// </summary>
         /// <param name="note">Note to play.</param>
         /// <param name="channel">Zero-based channel to play the note on.</param>
-        protected abstract void PlayNote(Note note, int channel);
+        /// <param name="time">Current playback time.</param>
+        protected abstract void PlayNote(Note note, int channel, TimeSpan time);
 
         /// <summary>
         /// Modifies referenced note up or down in tone by given number of steps. There are 12 steps per octave.


### PR DESCRIPTION
I needed the current, precise, playback time to properly buffer notes
into a PCM data stream.  If you have a better more elegant way of exposing this, please let me know.  I created a fork just so it was easier for me to pull fixes / changes.
